### PR TITLE
ci: Added prepare release PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,22 @@
+name: Prepare Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Type of release. patch or minor (major if breaking)
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release-notes:
+    uses: newrelic/node-newrelic/.github/workflows/prep-release.yml@main
+    with:
+      release_type: ${{ github.event.inputs.release_type }}
+      changelog_file: CHANGELOG.md
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/fn-inspect",
-  "version": "4.4.0",
+  "version": "4.3.0",
   "description": "Retrieve function name and line number from a function reference",
   "keywords": [
     "instrumentation"


### PR DESCRIPTION
This PR adds prepare-release so we can prep release before making one.  I also reverted the manual bump of version as we will rely on this workflow to do it for us.
