### PR TITLE
chore: disable husky and hardcode arm64 linux runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
         type: boolean
         required: true
         default: false
+env:
+  HUSKY: 0
+
 jobs:
   build_x86_x64:
     strategy:
@@ -73,14 +76,10 @@ jobs:
           path: prebuilds
 
   build_linux_arm:
-    # Skip this group if the PR doesn't originate from the main repo.
-    # Trying to run this on standard runners is just going to fail due to
-    # lack of CPU resources.
-    if: ${{ vars.NR_RUNNER != '' }}
     strategy:
       matrix:
         node: [ 18, 20, 22, 24 ]
-    runs-on: ${{ vars.NR_RUNNER }}
+    runs-on: ubuntu-24.04-arm 
     name: Linux / Node ${{ matrix.node }} arm64
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Create release was failing due to husky:

```sh
Run npm pack

> @newrelic/fn-inspect@4.4.0 prepare
> husky install

sh: 1: husky: not found
npm error code 127
npm error path /home/runner/work/node-fn-inspect/node-fn-inspect
npm error command failed
npm error command sh -c husky install
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-06-25T17_59_53_878Z-debug-0.log
```

This PR disables husky for the release process by setting the `HUSKY` environment variable to `0`. I also hardcode the ubuntu arm runner as it's publicly available now.
