### PR TITLE
chore: Updated `node-gyp` to 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
-    "node-gyp": "^11.2.0"
+    "node-gyp": "^12.3.0"
   }
 }


### PR DESCRIPTION
Updating `node-gyp` to latest to see if it fixes the test issues on windows.
